### PR TITLE
add `gen_SPcombo_v3` for arbitary n loop.

### DIFF
--- a/src/AmpTools.jl
+++ b/src/AmpTools.jl
@@ -32,7 +32,7 @@ export get_n_term_noexpand, get_n_term_expand, mul_by_term
 export get_n_loop, get_mom_conserv, make_SP, make_FV, split_SP, recover_SP
 export get_exponent, get_degree
 export split_coeff, drop_coeff, drop_coeff_keep_im
-export generate_SPcombo, gen_SPcombo_v2
+export generate_SPcombo, gen_SPcombo_v2, gen_SPcombo_v3
 export iszero_numerical
 export get_det, get_adj, get_dot
 export calc_sha256

--- a/test/test-gen_SPcombo_v3.jl
+++ b/test/test-gen_SPcombo_v3.jl
@@ -1,0 +1,10 @@
+using   Test
+using   AmpTools, SymEngine
+
+@testset "gen_SPcombo_v3" begin
+  for q1_rank ∈ 0:3, q2_rank ∈ 0:2, q3_rank ∈ 0:3, num_k ∈ 1:3
+    @show [ q1_rank, q2_rank, q3_rank ], [ Basic("k$ii") for ii ∈ 1:num_k ]
+    @test gen_SPcombo_v2( [ q1_rank, q2_rank, q3_rank ], [ Basic("k$ii") for ii ∈ 1:num_k ] ) == 
+        gen_SPcombo_v3( [ q1_rank, q2_rank, q3_rank ], [ Basic("k$ii") for ii ∈ 1:num_k ] )
+  end
+end # @testset


### PR DESCRIPTION
Plz check that:
```julia-repl
julia> setdiff(gen_SPcombo_v3([2, 2, 1], [k1, k2, k3]), gen_SPcombo_v2([2, 2, 1], Basic[k1, k2, k3]))
24-element Vector{Basic}:
          SP(q1, q3)*SP(k1, q2)^2*SP(k1, q1)
          SP(q1, q3)*SP(k1, q2)^2*SP(k2, q1)
          SP(q1, q3)*SP(k1, q2)^2*SP(k3, q1)
          SP(q1, q3)*SP(k1, q1)*SP(k2, q2)^2
          SP(q1, q3)*SP(k2, q2)^2*SP(k2, q1)
          SP(q1, q3)*SP(k2, q2)^2*SP(k3, q1)
          SP(q1, q3)*SP(k1, q1)*SP(k3, q2)^2
          SP(q1, q3)*SP(k2, q1)*SP(k3, q2)^2
          SP(q1, q3)*SP(k3, q2)^2*SP(k3, q1)
 SP(q1, q3)*SP(k1, q2)*SP(k1, q1)*SP(k2, q2)
 SP(q1, q3)*SP(k1, q2)*SP(k1, q1)*SP(k3, q2)
 SP(q1, q3)*SP(k1, q1)*SP(k2, q2)*SP(k3, q2)
            SP(q2, q2)*SP(q1, q3)*SP(k1, q1)
 SP(q1, q3)*SP(k1, q2)*SP(k2, q2)*SP(k2, q1)
 SP(q1, q3)*SP(k1, q2)*SP(k2, q1)*SP(k3, q2)
 SP(q1, q3)*SP(k1, q2)*SP(k2, q2)*SP(k3, q1)
 SP(q1, q3)*SP(k1, q2)*SP(k3, q2)*SP(k3, q1)
            SP(q1, q2)*SP(q1, q3)*SP(k1, q2)
 SP(q1, q3)*SP(k2, q2)*SP(k2, q1)*SP(k3, q2)
            SP(q2, q2)*SP(q1, q3)*SP(k2, q1)
 SP(q1, q3)*SP(k2, q2)*SP(k3, q2)*SP(k3, q1)
            SP(q1, q2)*SP(q1, q3)*SP(k2, q2)
            SP(q2, q2)*SP(q1, q3)*SP(k3, q1)
            SP(q1, q2)*SP(q1, q3)*SP(k3, q2)

julia> setdiff(gen_SPcombo_v2([2, 2, 1], [k1, k2, k3]), gen_SPcombo_v3([2, 2, 1], Basic[k1, k2, k3]))
Basic[]

```
It seems that the `SP_comb_list` generated from v2 is missing these terms.
Is it right?